### PR TITLE
Fix/gpx export chrome

### DIFF
--- a/web/src/lib/models/gpx/gpx.ts
+++ b/web/src/lib/models/gpx/gpx.ts
@@ -32,7 +32,7 @@ export default class GPX {
     $?: {
       version: string,
       creator: string,
-      'xmlns:prod': string,
+      xmlns: string,
       'xmlns:xsi': string,
       'xsi:schemaLocation': string,
     }
@@ -152,10 +152,9 @@ export default class GPX {
     allDatesToISOString(gpx);
 
     let xmlString = builder.buildObject(gpx);
-  
-    // Ensure xmlns is present in the root element
+
+    // Ensure xmlns is present in the root element for Firefox
     if (!xmlString.includes('xmlns="http://www.topografix.com/GPX/1/1"')) {
-      console.log("Adding missing \"xmlns\" to file.")
       xmlString = xmlString.replace('<gpx', '<gpx xmlns="http://www.topografix.com/GPX/1/1"');
     }
   

--- a/web/src/lib/models/gpx/gpx.ts
+++ b/web/src/lib/models/gpx/gpx.ts
@@ -154,8 +154,8 @@ export default class GPX {
     let xmlString = builder.buildObject(gpx);
 
     // Ensure xmlns is present in the root element for Firefox
-    if (!xmlString.includes('xmlns="http://www.topografix.com/GPX/1/1"')) {
-      xmlString = xmlString.replace('<gpx', '<gpx xmlns="http://www.topografix.com/GPX/1/1"');
+    if (!xmlString.includes(`xmlns="${defaultAttributes["xmlns"]}"`)) {
+      xmlString = xmlString.replace('<gpx', `<gpx xmlns="${defaultAttributes["xmlns"]}"`);
     }
   
     return xmlString;

--- a/web/src/lib/models/gpx/gpx.ts
+++ b/web/src/lib/models/gpx/gpx.ts
@@ -8,7 +8,7 @@ import Waypoint from './waypoint';
 const defaultAttributes = {
   version: '1.1',
   creator: 'wanderer',
-  'xmlns:prod': 'http://www.topografix.com/GPX/1/1',
+  xmlns: 'http://www.topografix.com/GPX/1/1',
   'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
   'xsi:schemaLocation':
     'http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd'
@@ -18,7 +18,7 @@ export default class GPX {
   $: {
     version: string;
     creator: string;
-    'xmlns:prod': string;
+    xmlns: string;
     'xmlns:xsi': string;
     'xsi:schemaLocation': string;
   }
@@ -151,6 +151,14 @@ export default class GPX {
     const gpx = new GPX(this);
     allDatesToISOString(gpx);
 
-    return builder.buildObject(gpx).replace('xmlns:prod', 'xmlns');
+    let xmlString = builder.buildObject(gpx);
+  
+    // Ensure xmlns is present in the root element
+    if (!xmlString.includes('xmlns="http://www.topografix.com/GPX/1/1"')) {
+      console.log("Adding missing \"xmlns\" to file.")
+      xmlString = xmlString.replace('<gpx', '<gpx xmlns="http://www.topografix.com/GPX/1/1"');
+    }
+  
+    return xmlString;
   }
 }


### PR DESCRIPTION
This fixes a trail export problem with Chrome-based browsers.

The export function used to add a duplicate "xmlns" attribute to the <gpx> tag in Chrome and Edge, which led to a malformed GPX file (see #128). Additionally, GeoJSONs were produced as empty lists, like `{"type":"FeatureCollection","features":[]}`.

I fixed the malformed XML issue by declaring the default namespace and adding it back in for Firefox (which seems to swallow it), instead of the other way around. By doing that, the second problem resolved itself as well and GeoJSONs are now produced as expected.

Tested in Edge and Firefox. All outputs tested to be valid JSON and XML files.