### PR TITLE
F/filter elevations

### DIFF
--- a/web/src/lib/models/gpx/gpx-metrics-computation.ts
+++ b/web/src/lib/models/gpx/gpx-metrics-computation.ts
@@ -1,0 +1,72 @@
+import { haversineDistance } from './utils';
+
+class GpxMetricsComputation {
+  private readonly thresholdXY_m: number;  // Distance threshold for filtering on the XY axis (latitude / longitude)
+  private readonly thresholdZ_m: number;  // Distance threshold for filtering on the Z axis (elevation)
+  private lastFilteredPointXY: any | null = null;
+  private lastFilteredZ: number | null = null;
+  private lastZ: number | null = null;
+  totalElevationGain = 0;
+  totalElevationLoss = 0;
+  totalElevationGainSmoothed = 0;
+  totalElevationLossSmoothed = 0;
+  totalDistance = 0;
+  totalDistanceSmoothed = 0;
+
+  constructor(thresholdXY_m: number, thresholdZ_m: number) {
+    this.thresholdXY_m = thresholdXY_m;
+    this.thresholdZ_m = thresholdZ_m;
+  }
+
+  addAndFilter(point: any) {
+    if (!this.lastFilteredPointXY) {
+      // Firstly, we are not yet filtering
+      this.lastFilteredPointXY = point;
+      this.lastFilteredZ = point.ele ?? 0;
+      this.lastZ = point.ele ?? 0;
+      return;
+    }
+
+    const distance = haversineDistance(
+      this.lastFilteredPointXY.$.lat,
+      this.lastFilteredPointXY.$.lon,
+      point.$.lat,
+      point.$.lon
+    );
+
+    this.totalDistance += distance;
+    const elevation = point.ele ?? 0;
+    // @ts-ignore I know this.lastZ is not null
+    const elevationDiff = elevation - this.lastZ;
+    this.lastZ = elevation;
+    if (elevationDiff > 0) {
+      this.totalElevationGain += elevationDiff;
+    }
+    if (elevationDiff < 0) {
+      this.totalElevationLoss -= elevationDiff;
+    }
+
+    if (distance < this.thresholdXY_m) {
+      return;
+    }
+
+    this.totalDistanceSmoothed += distance;
+
+    this.lastFilteredPointXY = point;
+    // @ts-ignore: I know this.lastFilteredZ is not null
+    const elevationDiffSmoothed = elevation - this.lastFilteredZ;
+
+    if (Math.abs(elevationDiffSmoothed) < this.thresholdZ_m) {
+      return;
+    }
+
+    this.lastFilteredZ = elevation;
+    if (elevationDiffSmoothed > 0) {
+      this.totalElevationGainSmoothed += elevationDiffSmoothed;
+    } else {
+      this.totalElevationLossSmoothed -= elevationDiffSmoothed;
+    }
+  }
+}
+
+export default GpxMetricsComputation;


### PR DESCRIPTION
### Summary of Changes

I’ve implemented the `GpxMetricsComputation` class in `web/src/lib/models/gpx/gpx-metrics-computation.ts`.

This class accumulates points from a GPX track and computes the following metrics:

- totalElevationGain
- totalElevationLoss
- totalElevationGainSmoothed
- totalElevationLossSmoothed
- totalDistance
- totalDistanceSmoothed

In `web/src/lib/models/gpx/gpx.ts`, the `getTotals()` method now uses this class to "smooth" elevation gain and loss, aiming for better accuracy.

### Implementation Details

I’ve chosen the following fixed thresholds:

- X/Y threshold: 5m
- Z threshold: 10m

These thresholds are currently not configurable, as they provide reasonably good results in most cases. However, depending on the track's characteristics we might need to adjust these thresholds in the future (e.g., a nearly flat track => lowering the Z threshold). Ho<ever, that's not easy, we would need a dataset with tracks and there known metrics.

### Next Steps

Feel free to merge this PR or suggest alternative strategies for the computation or threshold configuration.
