### PR TITLE
Clarify local build steps for Alpine-based Docker image (documentation)

### DIFF
--- a/docs/src/content/docs/getting-started/local-development.md
+++ b/docs/src/content/docs/getting-started/local-development.md
@@ -35,6 +35,12 @@ When you are done with development and would like to build wanderer for producti
 
 If you modified code in any of the `*.go` files make sure to build an updated binary with `go build`. In case you only edited tables via the `PocketBase` admin panel you don't need to do anything. The database will be migrated automatically.
 
+Since the Docker image is using Alpine linux with musl, you need to compile the binary
+using musl or using `CGO_ENABLED=false` as shown below.
+
+```bash
+env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o pocketbase_amd64
+```
 
 ### Frontend
 


### PR DESCRIPTION
## Description

Small doc update to clarify how to build the pocketbase binary when working with the Docker image.

The image uses Alpine + musl, so the binary needs to be compiled with `CGO_ENABLED=0` to produce full static binary to avoid issues. Added a quick note and example for that.

Another option is to build with musl with xgo, but that is more complicated.

## Future Improvements

If there are no objections, I will open a PR to Dockerfile which builds the binary inside the image - this way Dockerfile is more contained and builds more reproducible.

If people still want to use a binary which was pre-compiled else hwere (e.g. outside container for faster local development), they can use build arg to handle that.