### PR TITLE
Introduce new multi stage Docker image for DB component

### DIFF
--- a/.github/workflows/build_docker_images.yaml
+++ b/.github/workflows/build_docker_images.yaml
@@ -1,0 +1,80 @@
+name: Build Docker Images (DB)
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build_multistage:
+    name: Build Multi-Stage Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build Multi-Stage Docker Image
+        working-directory: ./db
+        run: |
+          docker build -f Dockerfile -t pocketbase:multistage .
+
+  build_local_binary:
+    name: Build Docker Image with Precompiled Binary (Static)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.23'
+
+      - name: Build binary externally
+        working-directory: ./db
+        run: |
+          # Build the binary and output it as "pocketbase_amd64"
+          env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -o pocketbase_amd64 .
+
+      - name: Build Docker Image with Local Binary
+        working-directory: ./db
+        run: |
+          # Pass TARGETARCH build arg (here "amd64") so the Dockerfile picks up the right file
+          docker build -f Dockerfile.pre_compiled --build-arg TARGETARCH=amd64 -t pocketbase:local .
+
+  build_non_static_binary:
+    name: Build Docker Image with Precompiled Binary (Non‑Static)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.23'
+
+      - name: Build binary without static linking (default CGO)
+        working-directory: ./db
+        run: |
+          # This build does not set CGO_ENABLED=0 so the binary will be dynamically linked.
+          go build -v -o pocketbase_amd64 .
+
+      - name: Attempt to Build Docker Image with Non‑Static Binary and Verify Failure
+        working-directory: ./db
+        run: |
+          set +e
+          docker build -f Dockerfile.pre_compiled --build-arg TARGETARCH=amd64 -t pocketbase:nonstatic .
+          EXIT_CODE=$?
+          echo "Docker build exit code: $EXIT_CODE"
+          if [ $EXIT_CODE -eq 0 ]; then
+            echo "Non‑static binary build unexpectedly succeeded"
+            exit 1
+          else
+            echo "Non‑static binary build failed as expected"
+            exit 0
+          fi

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,13 +1,44 @@
-FROM alpine:3.16
+# Stage 1: Build
+FROM golang:1.23-alpine AS builder
+
+WORKDIR /app
+
+# Copy go mod and sum files
+COPY go.mod go.sum ./
+
+# Download dependencies
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Set Go environment variables for static build
+ENV CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=amd64
+
+# Build the binary using the Go build cache.
+RUN --mount=type=cache,id=go-build,target=/root/.cache/go-build \
+    go build -v -o pocketbase_amd64
+
+# Stage 2: Final image
+FROM alpine:3.16 AS runtime
 
 WORKDIR /
 
+# Copy the binary from the builder stage
+COPY --from=builder /app/pocketbase_amd64 /pocketbase
+
+# Copy migrations
 COPY migrations ./migrations
 
-ARG TARGETARCH
-RUN echo ${TARGETARCH}
-COPY ./pocketbase_${TARGETARCH} /pocketbase
+# Make sure the binary is executable
 RUN chmod +x /pocketbase
+
+# Verify binary output contains expected version string
+RUN output="$(/pocketbase --version)" && \
+    echo "Version output: $output" && \
+    echo "$output" | grep -q 'pocketbase version (untracked)'
 
 ENV MEILI_URL=http://localhost:7700
 ENV MEILI_MASTER_KEY=

--- a/db/Dockerfile.pre_compiled
+++ b/db/Dockerfile.pre_compiled
@@ -1,0 +1,24 @@
+FROM alpine:3.16
+
+WORKDIR /
+
+COPY migrations ./migrations
+
+ARG TARGETARCH
+RUN echo ${TARGETARCH}
+COPY ./pocketbase_${TARGETARCH} /pocketbase
+RUN chmod +x /pocketbase
+
+# Verify binary output contains expected version string (aka binary is compiled for musl)
+# If you see "/bin/sh: /pocketbase: not found"
+# this likely means the binary is not compiled on / for musl
+RUN output="$(/pocketbase --version)" && \
+    echo "Version output: $output" && \
+    echo "$output" | grep -q 'pocketbase version (untracked)'
+
+ENV MEILI_URL=http://localhost:7700
+ENV MEILI_MASTER_KEY=
+
+EXPOSE 8090
+
+ENTRYPOINT ["/pocketbase", "serve", "--http=0.0.0.0:8090", "--dir=/pb_data"]


### PR DESCRIPTION
## Description

This pull request updates main `Dockerfile` to utilize multiple stages and build the binary inside the image as part of the build stage.

This should result in better developer experience and more reproducible builds.

If users want to use binary which has been pre-compiled locally outside the image (aka on host), they can do that `Dockerfile.pre_compiled` Dockerfile.

That one is almost the same as the original Dockerfile. I just added a check to fail in case the binary hasn't been correctly compiled locally (e.g. with `xgo` for `musl` or using `CGO_ENABLED=0`).

I also included a GHA workflow which builds the images to verify those files are working.

We could extend the original release workflow to build and push development version of images to Docker Hub / GHCR on each `main` branch run (we can use git commit sha as the image tag).

## TODO

- [ ] Get consensus on this change
- [ ] Update docs
- [ ] Verify Docker layer caching works
- [ ] Update release GHA workflow