### PR TITLE
Ignore Strava activities with no GPX data

### DIFF
--- a/db/integrations/strava/strava.go
+++ b/db/integrations/strava/strava.go
@@ -432,6 +432,10 @@ func fetchDetailedActivity(activity StravaActivity, accessToken string) (*Detail
 }
 
 func createTrailFromActivity(app core.App, activity *DetailedStravaActivity, gpx *filesystem.File, user string) error {
+	if len(activity.StartLatlng) < 2 {
+		return nil
+	}
+
 	collection, err := app.FindCollectionByNameOrId("trails")
 	if err != nil {
 		return err


### PR DESCRIPTION
Ignores activities where `StartLatlng` is empty.
Fixes #186 