### PR TITLE
Enhance Tags on TrailCard component with toggle support

### DIFF
--- a/web/src/lib/components/base/chip.svelte
+++ b/web/src/lib/components/base/chip.svelte
@@ -16,7 +16,7 @@
         ? 'bg-primary text-white'
         : 'border border-input-border bg-menu-item-background-hover'} px-2 py-1 rounded-full flex items-center gap-1"
 >
-    <span class="text-sm">{text}</span>
+    <span class="text-xs">{text}</span>
     {#if closable}
         <button
             type="button"

--- a/web/src/lib/components/trail/trail_card.svelte
+++ b/web/src/lib/components/trail/trail_card.svelte
@@ -39,6 +39,15 @@
     let trailIsShared = $derived(
         (trail.expand?.trail_share_via_trail?.length ?? 0) > 0,
     );
+
+    // expand and collapse the tags
+    let tags = trail.expand?.tags ?? [];
+    // svelte-ignore non_reactive_update
+    let expandedTags = false;
+
+    function toggleExpandTags() {
+        expandedTags = !expandedTags;
+    }
 </script>
 
 <div
@@ -122,10 +131,23 @@
                 </p>
             {/if}
             {#if trail.expand?.tags?.length}
-                <div class="flex flex-wrap gap-1 mb-3">
-                    {#each trail.expand?.tags ?? [] as t}
+                <div class="flex flex-wrap gap-1 mb-3 items-center">
+                    {#each (expandedTags ? tags : tags.slice(0, 2)) as t}
                         <Chip text={t.name} closable={false} primary={false}></Chip>
                     {/each}
+
+                    {#if tags.length > 2}
+                        <button
+                            onclick={toggleExpandTags}
+                            class="text-sm text-blue-600 hover:underline focus:outline-none"
+                        >
+                            {#if expandedTags}
+                                Show less
+                            {:else}
+                                +{tags.length - 2} more
+                            {/if}
+                        </button>
+                    {/if}
                 </div>
             {:else if trail.tags?.length}
                 <div class="flex flex-wrap gap-1 mb-3">


### PR DESCRIPTION
## Changes made
- modified tags on `trail_card.svelt` to show only first 2 tags by default
- added button after 2 tags to view more
- added function to allow for toggle of viewing more tags
- made text smaller in `chip.svelt`

## Why this is useful
- allows the `trail_card.svelt` to remain visual without taking away from the cover photo by using the tag options

## Screenshots
### Before
![Screenshot 2025-04-30 092259](https://github.com/user-attachments/assets/8401b41a-1e75-4b70-a18d-ef256dc101f5)
### After
![Screenshot 2025-04-30 092540](https://github.com/user-attachments/assets/0f52afce-f07d-48b6-abf1-71aca100e04c)

## Explanation
I like the use of adding tags to the trails but they take up a lot of space on the trail card view, taking away from the visual images of each trail. I made it so by default it will show the first 2 tags and show "+[x] more" which is a toggle allowing the user to expand the remaining tags if they choose to do so. I also made the text smaller "text-xs" on the `chip.svelt` to help with the visuals.