### PR TITLE
Add waypoints to printed PDF

### DIFF
--- a/web/src/lib/i18n/locales/en.json
+++ b/web/src/lib/i18n/locales/en.json
@@ -160,6 +160,7 @@
   "import": "Import",
   "import-hint": "Select or drag GPX, FIT, KML or TCX files here...",
   "include-description": "Include description",
+  "include-waypoints": "Include waypoints",
   "integration-description-komoot": "Syncs your komoot tours with wanderer in regular intervals.",
   "integration-description-strava": "Syncs your strava routes & activities with wanderer in regular intervals.",
   "integration-disabled": "integration disabled",


### PR DESCRIPTION
This PR adds a list of waypoints to the printed PDF of a trail. This doesn't currently print the waypoint images.

## Testing

I built and ran this locally using Docker. I printed without description or waypoints, with description only, with waypoints only, and with both enabled. These PDFs can be found below.

[description and waypoints.pdf](https://github.com/user-attachments/files/20401095/description.and.waypoints.pdf)
[description.pdf](https://github.com/user-attachments/files/20401096/description.pdf)
[waypoints.pdf](https://github.com/user-attachments/files/20401097/waypoints.pdf)
[neither description or waypoints.pdf](https://github.com/user-attachments/files/20401098/neither.description.or.waypoints.pdf)

Closes #304.
