### PR TITLE
Break long trail titles

### DIFF
--- a/web/src/lib/components/trail/trail_card.svelte
+++ b/web/src/lib/components/trail/trail_card.svelte
@@ -150,7 +150,7 @@
     {/if}
     <div class="p-4">
         <div>
-            <h4 class="font-semibold text-lg line-clamp-2">{trail.name}</h4>
+            <h4 class="font-semibold text-lg line-clamp-2 wrap-anywhere">{trail.name}</h4>
             {#if trail.date}
                 <p class="text-xs text-gray-500 mb-3">
                     {new Date(trail.date).toLocaleDateString(undefined, {

--- a/web/src/lib/components/trail/trail_info_panel.svelte
+++ b/web/src/lib/components/trail/trail_info_panel.svelte
@@ -353,7 +353,7 @@
                         title={trail.name}
                         class="{mode == 'map'
                             ? 'text-4xl'
-                            : 'text-5xl'} font-bold line-clamp-3 mb-1"
+                            : 'text-5xl'} font-bold line-clamp-3 mb-1 wrap-anywhere"
                         style="line-height: 1.18"
                     >
                         {trail.name}

--- a/web/src/lib/components/trail/trail_list_item.svelte
+++ b/web/src/lib/components/trail/trail_list_item.svelte
@@ -82,7 +82,7 @@
     </div>
     <div class="min-w-0 basis-full relative">
         <div class="flex items-center justify-between">
-            <h4 class="font-semibold text-lg">
+            <h4 class="font-semibold text-lg line-clamp-2 wrap-anywhere">
                 {trail.name}
             </h4>
             <div class="flex items-center shrink-0 gap-3">

--- a/web/src/lib/components/trail/trail_table.svelte
+++ b/web/src/lib/components/trail/trail_table.svelte
@@ -149,7 +149,7 @@
                         <td
                             class="flex justify-between items-center text-sm relative"
                         >
-                            <div class="p-4 w-[75%]" title={trail.name}>
+                            <div class="p-4 w-[75%] line-clamp-2 wrap-anywhere" title={trail.name}>
                                 {trail.name}
                             </div>
                             <div class="flex flex-col items-center">


### PR DESCRIPTION
Importing gpx trails can give them long single word names which are hard to read in the current UI. This PR improves that (at least somewhat).

Example for cards below.

**Before:**
<img width="656" height="420" alt="before" src="https://github.com/user-attachments/assets/b3d6b2ce-e9bc-4859-b9c5-9e3a3c01d38c" />

**After:**
<img width="643" height="423" alt="after" src="https://github.com/user-attachments/assets/ef2ed004-101e-4020-875a-c93e6692f1b9" />
