### PR TITLE
improve some elements for dark mode

### DIFF
--- a/docs/src/tailwind.css
+++ b/docs/src/tailwind.css
@@ -24,6 +24,8 @@
     --input-border-focus: 148, 163, 184;
     --input-ring: 148, 163, 184;
 
+    --toggle-active: 75, 85, 99;
+
     --menu-background: 30, 32, 40;
     --menu-item-background-hover: 55, 65, 81;
     --menu-item-background-focus: 75, 85, 99;
@@ -51,6 +53,8 @@
     --input-border: 209, 213, 219;
     --input-border-focus: 36, 39, 52;
     --input-ring: 148, 163, 184;
+
+    --toggle-active: 36, 39, 52;
 
     --menu-background: 255, 255, 255;
     --menu-item-background-hover: 243, 244, 246;

--- a/web/src/css/app.css
+++ b/web/src/css/app.css
@@ -24,6 +24,7 @@
     --color-input-border: rgba(var(--input-border));
     --color-input-border-focus: rgba(var(--input-border-focus));
     --color-input-ring: rgba(var(--input-ring));
+    --color-toggle-active: rgba(var(--toggle-active));
     --color-menu-background: rgba(var(--menu-background));
     --color-menu-item-background-hover: rgba(var(--menu-item-background-hover));
     --color-menu-item-background-focus: rgba(var(--menu-item-background-focus));

--- a/web/src/css/theme.css
+++ b/web/src/css/theme.css
@@ -16,6 +16,8 @@
     --input-border-focus: 36, 39, 52;
     --input-ring: 148, 163, 184;
 
+    --toggle-active: 36, 39, 52;
+
     --menu-background: 255, 255, 255;
     --menu-item-background-hover: 243, 244, 246;
     --menu-item-background-focus: 229, 231, 235;
@@ -45,6 +47,8 @@
     --input-border: 50, 54, 64;
     --input-border-focus: 148, 163, 184;
     --input-ring: 148, 163, 184;
+
+    --toggle-active: 75, 85, 99;
 
     --menu-background: 30, 32, 40;
     --menu-item-background-hover: 55, 65, 81;

--- a/web/src/lib/components/base/datepicker.svelte
+++ b/web/src/lib/components/base/datepicker.svelte
@@ -28,7 +28,7 @@
     <div class="flex items-center gap-2">
         <input
             {name}
-            class="bg-input-background border border-input-border rounded-md p-3 transition-colors focus:border-input-border-focus focus:outline-none focus:ring-0 w-full"
+            class="bg-input-background border border-input-border rounded-md p-3 transition-colors focus:border-input-border-focus focus:outline-none focus:ring-0 w-full dark:[color-scheme:dark]"
             class:border-red-400={(error?.length ?? 0) > 0}
             class:bg-input-background-error={(error?.length ?? 0) > 0}
             type="date"

--- a/web/src/lib/components/base/toggle.svelte
+++ b/web/src/lib/components/base/toggle.svelte
@@ -39,7 +39,7 @@
             onchange={handleToggleChange}
         />
         <div
-            class="w-11 h-6 bg-input-background border border-input-border peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-input-ring rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary"
+            class="w-11 h-6 bg-input-background border border-input-border peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-input-ring rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-toggle-active"
         ></div>
         {#if label}
             <span class="ms-3 text-sm font-medium">{label}</span>


### PR DESCRIPTION
Hi,

### Calendar input (Chrome only)
In Chrome, the calendar icon was black:
<img width="356" height="95" alt="cal_chrome_before" src="https://github.com/user-attachments/assets/1166e1cf-923e-4e17-91f2-a92f2c895762" />

Fixed:
<img width="342" height="96" alt="cal_chrome_after" src="https://github.com/user-attachments/assets/a5e57a30-ff1a-4f93-a919-d0d842812e1c" />



### Private/Public toggle
The toggle element for trail visibility (private/public) is fine in light mode, but the private/public colors in dark mode are too similar.

Light / private:
<img width="175" height="52" alt="toggle_light_private" src="https://github.com/user-attachments/assets/7e791303-87aa-4c87-bb0f-ad84e51dcfcf" />

Light / public:
<img width="182" height="44" alt="toggle_light_public" src="https://github.com/user-attachments/assets/b5f71d54-a31e-4b4b-9ba7-42ba06af9340" />

Dark / private:
<img width="205" height="55" alt="toggle_dark_private" src="https://github.com/user-attachments/assets/1f727805-3efb-4fb5-b96e-4934a4a3f1ed" />

Dark / public (current):
<img width="183" height="56" alt="toggle_dark_public_before" src="https://github.com/user-attachments/assets/6dadce61-aed7-44ab-977d-f0942a6d5684" />

Dark / public (suggestion):
<img width="216" height="51" alt="toggle_dark_public_after" src="https://github.com/user-attachments/assets/91199dd5-1faf-4459-b0e4-464346fd94a0" />


I hope you like it.

Kind regards